### PR TITLE
Use pylatexenc to replace special characters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ extras_require = dict(
     dev=["pre-commit", "bump2version"],
 )
 
-install_requires = ["Click", "crossrefapi", "diskcache", "requests", "pyyaml", "tqdm"]
+install_requires = ["Click", "crossrefapi", "diskcache", "requests", "pyyaml", "tqdm", "pylatexenc"]
 
 
 setup(

--- a/yaml2bib/_yaml2bib.py
+++ b/yaml2bib/_yaml2bib.py
@@ -11,6 +11,7 @@ import crossref.restful
 import diskcache
 import requests
 import yaml
+from pylatexenc.latexencode import unicode_to_latex
 from tqdm import tqdm
 
 
@@ -43,13 +44,8 @@ def cached_crossref(doi: str, works: crossref.restful.Works, database: str) -> s
 def replace_special_letters(x):
     # XXX: I am not sure whether these substitutions are needed.
     # the problem seemed to be the utf-8 `requests.get` encoding.
-    to_replace = [("ö", r"\"{o}"), ("ü", r"\"{u}"), ("ë", r"\"{e}"), ("ï", r"\"{i}")]
 
-    for old, new in to_replace:
-        x = x.replace(old, new)
-        x = x.replace(old.upper(), new.upper())
-
-    return x
+    return unicode_to_latex(x, non_ascii_only=True)
 
 
 def replace_key(
@@ -333,7 +329,6 @@ def cli(
         crossref_database=crossref_database,
         email=email,
     )
-
 
 if __name__ == "__main__":
 

--- a/yaml2bib/_yaml2bib.py
+++ b/yaml2bib/_yaml2bib.py
@@ -41,13 +41,6 @@ def cached_crossref(doi: str, works: crossref.restful.Works, database: str) -> s
         return info
 
 
-def replace_special_letters(x):
-    # XXX: I am not sure whether these substitutions are needed.
-    # the problem seemed to be the utf-8 `requests.get` encoding.
-
-    return unicode_to_latex(x, non_ascii_only=True)
-
-
 def replace_key(
     key: str,
     data,
@@ -59,7 +52,8 @@ def replace_key(
     bib_context = bib_entry.split(",", maxsplit=1)[1]
     # Now only modify `bib_context` because we don't want to touch the key.
 
-    bib_context = replace_special_letters(bib_context)
+    # Replace non-ascii characters by LaTeX equivalent
+    bib_context = unicode_to_latex(bib_context, non_ascii_only=True)
 
     to_replace = replacements.copy()
 
@@ -329,6 +323,7 @@ def cli(
         crossref_database=crossref_database,
         email=email,
     )
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
Currently, `yaml2bib.replace_special_letters` is used to replace some special characters by their LaTeX equivalent. This PR implements `pylatexenc.unicode_to_latex` as a more general alternative.

`unicode_to_latex` is called with `non_ascii_only=True` to prevent brackets etc. from being subsituted.